### PR TITLE
Restore semaphore on failure creating new conn

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -91,6 +91,8 @@ func (c *channelPool) Get(ctx context.Context) (net.Conn, error) {
 	case c.semaphore <- struct{}{}:
 		conn, err := factory()
 		if err != nil {
+			// restore claimed slot, otherwise max is permanently decreased
+			<-c.semaphore
 			return nil, err
 		}
 


### PR DESCRIPTION
This fixes #4 by restoring the claimed semaphore when `factory()` returns an error.